### PR TITLE
Cover subdomain change and switch to fragment update

### DIFF
--- a/zoomkiller.js
+++ b/zoomkiller.js
@@ -1,6 +1,6 @@
 chrome.webNavigation.onCompleted.addListener((details) => {
     chrome.tabs.remove(details.tabId, () => {});
-}, {url: [{urlMatches : 'https://zoom.us/postattendee'}]});
+}, {url: [{urlMatches : 'https://*.zoom.us/postattendee'}]});
 
 chrome.webNavigation.onCompleted.addListener((details) => {
     setTimeout(() => {

--- a/zoomkiller.js
+++ b/zoomkiller.js
@@ -7,3 +7,9 @@ chrome.webNavigation.onCompleted.addListener((details) => {
         chrome.tabs.remove(details.tabId, () => {});
     }, 10000);
 }, {url: [{hostSuffix : 'zoom.us', querySuffix: 'status=success'}]});
+
+chrome.webNavigation.onReferenceFragmentUpdated.addListener((details) => {
+    if (details.url.endsWith('#success')) {
+        chrome.tabs.remove(details.tabId, () => {});
+    }
+}, {url: [{hostSuffix : 'zoom.us'}]});


### PR DESCRIPTION
Hello!

This extension stopped working for me, so I thought I'd check out the problem.  Two things I noticed:
- The host for the "postattendee" screen had changed (TBH, I'm not sure how to make that happen again, so not tested :-( 
- The "success" marker had been moved from being in the query to a fragment update on the page (i.e. the URL ends with `success`). That case I was able to test and works like a charm :-) 