### PR TITLE
Adds timeout to all tabs.remove invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Let ZOOM TAB KILLER take care of business!
 
 ZOOM TAB KILLER will close the ZOOM meeting tab 10 sec. after the "success=true" query param is added or  meeting is done and the page navigates to /postattendee
 
-[![Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/ecljipopiofdehgkinhohnldfaogdipo)
+[![Chrome Web Store](https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/ecljipopiofdehgkinhohnldfaogdipo)

--- a/zoomkiller.js
+++ b/zoomkiller.js
@@ -1,5 +1,7 @@
 chrome.webNavigation.onCompleted.addListener((details) => {
-    chrome.tabs.remove(details.tabId, () => {});
+    setTimeout(() => {
+        chrome.tabs.remove(details.tabId, () => {});
+    }, 10000);
 }, {url: [{urlMatches : 'https://*.zoom.us/postattendee'}]});
 
 chrome.webNavigation.onCompleted.addListener((details) => {
@@ -10,6 +12,8 @@ chrome.webNavigation.onCompleted.addListener((details) => {
 
 chrome.webNavigation.onReferenceFragmentUpdated.addListener((details) => {
     if (details.url.endsWith('#success')) {
-        chrome.tabs.remove(details.tabId, () => {});
+        setTimeout(() => {
+            chrome.tabs.remove(details.tabId, () => {});
+        }, 10000);
     }
 }, {url: [{hostSuffix : 'zoom.us'}]});


### PR DESCRIPTION
This PR does two things:

1. Fixes the issue https://github.com/ptelad/zoom-tab-killer/issues/4 
2. Fixes the broken badge on the README, using a reference one from [Google Branding Guidelines](https://developer.chrome.com/docs/webstore/branding/)
![image](https://user-images.githubusercontent.com/3652509/117902470-e406db00-b2a3-11eb-9234-d6be1941f5e1.png)
